### PR TITLE
Feature: Add remote browser/cluster support

### DIFF
--- a/TikTokApi/tiktok.py
+++ b/TikTokApi/tiktok.py
@@ -251,9 +251,11 @@ class TikTokApi:
                 headless = False  # managed by the arg
 
             if ws_endpoint:
-                print(f'Connecting to remote Playwrite at {ws_endpoint}...', end=' ')
-                self.browser = await self.playwright.chromium.connect(ws_endpoint=ws_endpoint)
-                print('success!')
+                print(f"Connecting to remote Playwright at {ws_endpoint}...", end=" ")
+                self.browser = await self.playwright.chromium.connect(
+                    ws_endpoint=ws_endpoint
+                )
+                print("success!")
             else:
                 self.browser = await self.playwright.chromium.launch(
                     headless=headless, args=override_browser_args, proxy=random_choice(proxies), executable_path=executable_path

--- a/TikTokApi/tiktok.py
+++ b/TikTokApi/tiktok.py
@@ -213,7 +213,8 @@ class TikTokApi:
         cookies: list[dict] = None,
         suppress_resource_load_types: list[str] = None,
         browser: str = "chromium",
-        executable_path: str = None
+        executable_path: str = None,
+        ws_endpoint: str = None
     ):
         """
         Create sessions for use within the TikTokApi class.
@@ -234,6 +235,7 @@ class TikTokApi:
             suppress_resource_load_types (list[str]): Types of resources to suppress playwright from loading, excluding more types will make playwright faster.. Types: document, stylesheet, image, media, font, script, textrack, xhr, fetch, eventsource, websocket, manifest, other.
             browser (str): specify either firefox or chromium, default is chromium
             executable_path (str): Path to the browser executable
+            ws_endpoint (str): Websocket endpoint to connect to a remote browser instead of launching a local one
 
         Example Usage:
             .. code-block:: python
@@ -247,10 +249,19 @@ class TikTokApi:
             if headless and override_browser_args is None:
                 override_browser_args = ["--headless=new"]
                 headless = False  # managed by the arg
-            self.browser = await self.playwright.chromium.launch(
-                headless=headless, args=override_browser_args, proxy=random_choice(proxies), executable_path=executable_path
-            )
+
+            if ws_endpoint:
+                print(f'Connecting to remote Playwrite at {ws_endpoint}...', end=' ')
+                self.browser = await self.playwright.chromium.connect(ws_endpoint=ws_endpoint)
+                print('success!')
+            else:
+                self.browser = await self.playwright.chromium.launch(
+                    headless=headless, args=override_browser_args, proxy=random_choice(proxies), executable_path=executable_path
+                )
         elif browser == "firefox":
+            if ws_endpoint:
+                print('Firefox does not support remote connections, ignoring ws_endpoint')
+
             self.browser = await self.playwright.firefox.launch(
                 headless=headless, args=override_browser_args, proxy=random_choice(proxies), executable_path=executable_path
             )


### PR DESCRIPTION
## Summary

Primary change is adding the ability to [connect](https://playwright.dev/python/docs/api/class-browsertype#browser-type-connect) to an existing Playwright session.

Now that we have https://playwright-playwright.chartmetric.com, we can use this to connect to Playwright sessions running on the ECS cluster. This means we aren't using Airflow resources to spin browsers up and down and lets us scale servers independently of ingestion.

### Cluster setup

These changes weren't reviewed, but there's two elements to the new cluster:
1. A new `Dockerfile-playwright` and supporting files in the `playwright-cluster/` directory of the new `playwright` branch on `chartmetric_data_script`
    * Changes to the container configuration are automatically deployed to the cluster using a slight tweak to the `build-push.yaml` on that branch
2. A new ECS cluster to deploy that `Dockerfile-playwright` via [this chartmetric-infra change](https://github.com/chartmetric/chartmetric-infra/commit/b25b21cf221ad00bad317b05d206a727e11af085)
    * Note that the environment name is `playwright` to use the `playwright` branch of `chartmetric_data_script` and, simultaneously, the Dockerfile suffix is `playwright` to use the `Dockefile-playwright` file. This results in the final URL being `https://playwright-playwright.chartmetric.com`, but I didn't see it as technically inaccurate. In the future, we may want separate browser clusters per environment / use case, so the duplication of the name highlights the potential for this.

### Monitoring

I setup [a Grafana dashboard to monitor any ECS cluster/service](https://grafana.monitoring.chartmetric.com/d/fdxce7w6bucxsf/ecs-monitoring-custom?orgId=1&from=1725866566834&to=1725868366834&var-cluster=chartmetric-playwright-playwright-cluster&var-service=chartmetric-playwright-playwright-service&refresh=5s) after [connecting Grafana to CloudWatch](https://chartmetric.slack.com/archives/C06JV2BANF5/p1725854216194329?thread_ts=1725854144.860699&cid=C06JV2BANF5).

![image](https://github.com/user-attachments/assets/4d06fd4e-8ce7-4454-a3bc-3451157e3195)

This is how I validated the "keep alive" functionality which maintains idle browser instances
![image](https://github.com/user-attachments/assets/adb5dbb9-2e05-40af-bb87-f2719de6d496)
_1 is before the idle functionality was added, the arrow is the deployment, 2 is after_

### Extra logs

I added a few extra `logger.info`s to the class code to make it obvious when we're connecting to the cluster vs. spinning up a local browser.

### `recreate_sessions`

This isn't completely necessary, but I found that sometimes API calls would begin hanging because the `api` object wasn't smart enough to restart crashed sessions.

## Commits
- **add ws_endpoint parameter to create_sessions to allow connecting to ECS cluster**
- **correct typo**
- **add better logging and automatic session recreation**


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208233378259907