### PR TITLE
use novel version 6.3.3 instead of 6.4.0 which is already used by davidteather/TikTok-Api

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 setuptools.setup(
     name="TikTokApi",
     packages=setuptools.find_packages(),
-    version="6.4.0",
+    version="6.3.3",
     license="MIT",
     description="The Unofficial TikTok API Wrapper in Python 3.",
     author="David Teather",


### PR DESCRIPTION
I'm not sure, but I think the official v6.4.0 was resolving ahead of ours, so it wasn't pulling in the new functionality.

Hopefully this fixes it!
